### PR TITLE
Replace gffcompare with stringtie --merge

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -31,6 +31,9 @@ process {
   withName:StringTie2 {
     container = 'quay.io/biocontainers/stringtie:2.0--hc900ff6_0'
   }
+  withName:StringTie2Merge {
+    container = 'quay.io/biocontainers/stringtie:2.0--hc900ff6_0'
+  }
   withName:FeatureCounts {
     container = 'quay.io/biocontainers/subread:2.0.1--hed695b0_0'
   }

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   # TODO nf-core: Add required software dependencies here
   - fastqc=0.11.8
   - multiqc=1.7
-  - gffcompare=0.11.2
   - r-base=4.0.1
   - r-devtools=2.3.0
   - bioconductor-deseq2=1.28.0

--- a/main.nf
+++ b/main.nf
@@ -216,7 +216,7 @@ ch_annot
    .unique()
    .set{ch_annotation}
 
-process GffCompare {
+process StringTie2Merge {
     publishDir "${params.outdir}/stringtie2", mode: 'copy',
         saveAs: { filename ->
                       if (!filename.endsWith(".version")) filename
@@ -235,13 +235,9 @@ process GffCompare {
     script:
     """
     ls -d -1 $PWD/$stringtie_dir/*.out.gtf > gtf_list.txt
-    echo "$annot" >> gtf_list.txt
-    gffcompare -i gtf_list.txt -o merged
-    gffcompare --version &> gffcompare.version
+    stringtie --merge gtf_list.txt -G $annot -o merged.combined.gtf
     """
 }
-
-
 
 process FeatureCounts {
      publishDir "${params.outdir}", mode: 'copy',


### PR DESCRIPTION
The pipeline can now run with stringtie --merge successfully:
![Screen Shot 2020-07-02 at 9 36 15 AM](https://user-images.githubusercontent.com/41866052/86307161-a6c7ca80-bc48-11ea-9bef-75c563dc3167.png)
The merged.combined.gtf from the StringTie2Merge process has a 96,167 unique transcript_ids and 1,036,246 exons, where the original genes.gtf from igenome has 95,252 unique transcript_ids.
